### PR TITLE
Fix join/translation of split CDS and add AA FASTA output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2](https://github.com/CFIA-NCFAD/gfflu/releases/tag/0.0.2) - 2023-08-09
+
+### Fixed
+
+* Handling of CDS with joins (e.g. `join(24..49,738..1005)` for M2 of MH085255) is now properly combined and translated to amino acid sequence (#1)
+
+### Added
+
+* Amino acid FASTA output for all CDS and other features that can be translated to peptides (`{outdir}/{prefix}.faa`)
+
 ## [0.0.1](https://github.com/CFIA-NCFAD/gfflu/releases/tag/0.0.1) - 2023-06-09
 
 First release of gfflu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Handling of CDS with joins (e.g. `join(24..49,738..1005)` for M2 of MH085255) is now properly combined and translated to amino acid sequence (#1)
+* Handling of CDS with joins (e.g. `join(24..49,738..1005)` for M2 of MH085255) is now properly combined and translated to amino acid sequence (#3)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Produces an output directory `gfflu-outdir/` by default with the following files
 $ tree gfflu-outdir/
 gfflu-outdir/
 ├── Segment_4_HA.MH201222.blastx.tsv
+├── Segment_4_HA.MH201222.faa
 ├── Segment_4_HA.MH201222.gbk
 ├── Segment_4_HA.MH201222.gff
 └── Segment_4_HA.MH201222.miniprot.gff
@@ -57,8 +58,6 @@ gfflu-outdir/
 Help output:
 
 ```console
-$ gfflu --help
-                                                                                                                                                                                                                                        
  Usage: gfflu [OPTIONS] FASTA                                                                                                                                                                                                           
                                                                                                                                                                                                                                         
  Annotate Influenza A virus sequences using Miniprot and BLASTX                                                                                                                                                                         
@@ -66,11 +65,11 @@ $ gfflu --help
  with SnpEff.                                                                                                                                                                                                                           
                                                                                                                                                                                                                                         
 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ *    fasta      FILE  [default: None] [required]                                                                                                                                                                                     │
+│ *    fasta      FILE  Influenza virus nucleotide sequence FASTA file [default: None] [required]                                                                                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --outdir              -o      PATH  Output directory [default: gfflu-outdir]                                                                                                                                                         │
-│ --force               -f                                                                                                                                                                                                             │
+│ --force               -f            Overwrite existing files                                                                                                                                                                         │
 │ --prefix              -p      TEXT  Output file prefix [default: None]                                                                                                                                                               │
 │ --verbose             -v                                                                                                                                                                                                             │
 │ --version             -V            Print 'gfflu version 0.0.2' and exit                                                                                                                                                             │
@@ -79,7 +78,7 @@ $ gfflu --help
 │ --help                              Show this message and exit.                                                                                                                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                                                                                                                                         
- gfflu version 0.0.2; Python 3.10.5
+ gfflu version 0.0.2; Python 3.10.5               
 ```
 
 ## Installation

--- a/src/gfflu/annotation.py
+++ b/src/gfflu/annotation.py
@@ -33,7 +33,7 @@ def run_annotation(fasta: Path, outdir: Path, prefix: str) -> SeqRecord:
     if gffrec is None or len(gffrec) == 0:
         return seqrec
     blastx_b6 = run_blastx(outdir, fasta, prefix)
-    gffrec.seq = list(SeqIO.parse(fasta, "fasta"))[0].seq
+    gffrec.seq = next(iter(SeqIO.parse(fasta, "fasta"))).seq
     # remove annotations so that SnpEff doesn't have any issues with the GFF file
     gffrec.annotations = {}
     gene_features = get_features_by_gene(gffrec)
@@ -42,7 +42,7 @@ def run_annotation(fasta: Path, outdir: Path, prefix: str) -> SeqRecord:
     # HA signal peptide is too small for Miniprot to detect
     if any(gene == "HA" for (gene, ftype, product) in gene_features):
         # get CDS feature for HA
-        cds_feature = [x for x in top_features for y in x.sub_features if y.type == "CDS"][0]
+        cds_feature = next(x for x in top_features for y in x.sub_features if y.type == "CDS")
         cds_feature.sub_features.append(find_HA_signal_peptide(seqrec, cds_feature))
     # merge sub_features by gene
     top_features = merge_subfeatures_by_gene(top_features)

--- a/src/gfflu/cli.py
+++ b/src/gfflu/cli.py
@@ -9,7 +9,7 @@ from Bio import SeqIO
 
 from gfflu.__about__ import __version__
 from gfflu.annotation import run_annotation
-from gfflu.io import check_gff, write_gff
+from gfflu.io import check_gff, write_gff, write_aa_fasta
 
 app = typer.Typer()
 
@@ -88,6 +88,9 @@ def main(
     gbk_path = outdir / f"{prefix}.gbk"
     logger.info(f"Writing {gbk_path}")
     SeqIO.write(check_gff([rec], "DNA"), gbk_path, "genbank")
+    aa_fasta = outdir / f"{prefix}.faa"
+    logger.info(f"Writing amino acid FASTA file '{aa_fasta}'")
+    write_aa_fasta(rec, prefix, aa_fasta)
     logger.info("Done!")
 
 

--- a/src/gfflu/cli.py
+++ b/src/gfflu/cli.py
@@ -9,7 +9,7 @@ from Bio import SeqIO
 
 from gfflu.__about__ import __version__
 from gfflu.annotation import run_annotation
-from gfflu.io import check_gff, write_gff, write_aa_fasta
+from gfflu.io import check_gff, write_aa_fasta, write_gff
 
 app = typer.Typer()
 

--- a/src/gfflu/gene_segments/segment_2_pb1.py
+++ b/src/gfflu/gene_segments/segment_2_pb1.py
@@ -56,7 +56,7 @@ def find_PB1_F2(fasta: Path, blastx: Path) -> Optional[SeqFeature]:
     pb1_f2_start = df_pb1_f2["qstart"][0]
     pb1_f2_start = pb1_f2_start - 1
     pb1_f2_subjectid = df_pb1_f2["subject"][0]
-    seqrec: SeqRecord = list(SeqIO.parse(fasta, "fasta"))[0]
+    seqrec: SeqRecord = next(iter(SeqIO.parse(fasta, "fasta")))
     seq_from_pb1_f2_start = seqrec.seq[pb1_f2_start:]
     pb1_f2_aa = str(seq_from_pb1_f2_start.translate())
     # find the first stop codon and add 1 to get the length of the PB1-F2 protein including stop codon

--- a/src/gfflu/io.py
+++ b/src/gfflu/io.py
@@ -1,12 +1,15 @@
 import logging
 import os
 from pathlib import Path
-from typing import Iterable, List, Optional
 
 from BCBio import GFF
 from Bio import SeqIO
+from Bio.Seq import Seq
+from Bio.SeqFeature import CompoundLocation, FeatureLocation
+from Bio.SeqIO.InsdcIO import _insdc_location_string
 from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
+from typing import Iterable, List, Optional, Union
 
 logger = logging.getLogger(__name__)
 
@@ -31,30 +34,78 @@ def flatten_features(rec: SeqRecord) -> SeqRecord:
     source: https://github.com/chapmanb/bcbb/blob/81442c07173aaa59cbc1be33dd4a6e0eee87c5f6/gff/Scripts/gff/gff_to_genbank.py#L52
     """
     out = []
-    for f in rec.features:
-        cur = [f]
-        while cur:
-            nextf = []
-            for curf in cur:
-                out.append(curf)
-                if not hasattr(curf, "sub_features"):
+    for feature in rec.features:
+        features = [feature]
+        while features:
+            next_features = []
+            for current_feature in features:
+                out.append(current_feature)
+                if not hasattr(current_feature, "sub_features"):
                     continue
-                sub_features: Optional[List[SeqFeature]] = curf.sub_features
+                new_features = []
+                sub_features: Optional[List[SeqFeature]] = current_feature.sub_features
                 if sub_features:
+                    cds_subfeatures = [x for x in sub_features if x.type == "CDS"]
+                    if len(cds_subfeatures) > 1:
+                        subf = cds_subfeatures[0]
+                        locations = [x.location for x in cds_subfeatures]
+                        new_location = CompoundLocation(locations)
+                        subf.location = new_location
+                        subf.qualifiers["translation"] = [get_translation(rec.seq, new_location)]
+                        new_features.append(subf)
+                    else:
+                        subf = cds_subfeatures[0]
+                        subf.qualifiers["translation"] = [get_translation(rec.seq, subf.location)]
+                        new_features.append(subf)
                     for subf in sub_features:
-                        if subf.type == "CDS":
-                            translation = rec.seq[subf.location.start : subf.location.end].translate()
-                            if translation[-1] == "*":
-                                translation = translation[:-1]
-                            subf.qualifiers["translation"] = [translation]
-                        elif subf.type == "signal_peptide_region_of_CDS":
+                        if subf.type == "signal_peptide_region_of_CDS":
                             subf.type = "sig_peptide"
                         elif subf.type == "mature_protein_region_of_CDS":
                             subf.type = "mat_peptide"
-                    nextf.extend(sub_features)
-            cur = nextf
+                        else:
+                            continue
+                        subf.qualifiers["translation"] = [get_translation(rec.seq, subf.location)]
+                        try:
+                            subf.qualifiers["gene"] = [feature.qualifiers["gene"][0]]
+                        except KeyError:
+                            pass
+                        try:
+                            subf.qualifiers["product"] = [feature.qualifiers["product"][0]]
+                        except KeyError:
+                            pass
+                        new_features.append(subf)
+                    next_features.extend(new_features)
+            features = next_features
     rec.features = out
     return rec
+
+
+def get_translation(seq: Seq, location: Union[FeatureLocation, CompoundLocation]) -> str:
+    """Get translation of sequence from start to end"""
+    translation = location.extract(seq).translate()
+    if translation[-1] == "*":
+        translation = translation[:-1]
+    return translation
+
+
+def write_aa_fasta(flat_rec: SeqRecord, prefix: str, out_file: os.PathLike) -> None:
+    """Write out FASTA file with amino acid sequences"""
+    with open(out_file, "w") as out_handle:
+        for feature in flat_rec.features:
+            if feature.type not in {"CDS", "mat_peptide", "sig_peptide"}:
+                continue
+            translation = get_translation(flat_rec.seq, feature.location)
+            try:
+                gene = feature.qualifiers['gene'][0]
+            except KeyError:
+                gene = ""
+            try:
+                product = feature.qualifiers['product'][0]
+            except KeyError:
+                product = ""
+            location_str = _insdc_location_string(location=feature.location, rec_length=len(flat_rec.seq))
+            out_handle.write(
+                f">{prefix}|{feature.type}|{gene}|{location_str} {product}\n{translation}\n")
 
 
 def read_gff(gff: Path) -> Optional[SeqRecord]:

--- a/src/gfflu/io.py
+++ b/src/gfflu/io.py
@@ -1,15 +1,14 @@
 import logging
 import os
 from pathlib import Path
+from typing import Iterable, List, Optional, Union
 
 from BCBio import GFF
 from Bio import SeqIO
 from Bio.Seq import Seq
-from Bio.SeqFeature import CompoundLocation, FeatureLocation
+from Bio.SeqFeature import CompoundLocation, FeatureLocation, SeqFeature
 from Bio.SeqIO.InsdcIO import _insdc_location_string
-from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
-from typing import Iterable, List, Optional, Union
 
 logger = logging.getLogger(__name__)
 
@@ -96,16 +95,15 @@ def write_aa_fasta(flat_rec: SeqRecord, prefix: str, out_file: os.PathLike) -> N
                 continue
             translation = get_translation(flat_rec.seq, feature.location)
             try:
-                gene = feature.qualifiers['gene'][0]
+                gene = feature.qualifiers["gene"][0]
             except KeyError:
                 gene = ""
             try:
-                product = feature.qualifiers['product'][0]
+                product = feature.qualifiers["product"][0]
             except KeyError:
                 product = ""
             location_str = _insdc_location_string(location=feature.location, rec_length=len(flat_rec.seq))
-            out_handle.write(
-                f">{prefix}|{feature.type}|{gene}|{location_str} {product}\n{translation}\n")
+            out_handle.write(f">{prefix}|{feature.type}|{gene}|{location_str} {product}\n{translation}\n")
 
 
 def read_gff(gff: Path) -> Optional[SeqRecord]:


### PR DESCRIPTION
### Fixed

* Handling of CDS with joins (e.g. `join(24..49,738..1005)` for M2 of MH085255) is now properly combined and translated to amino acid sequence (#3 )

### Added

* Amino acid FASTA output for all CDS and other features that can be translated to peptides (`{outdir}/{prefix}.faa`)